### PR TITLE
Fix URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # Theta Tools
 
-'Theta Tools' are a group of useful tools, components, and templates that can be used in any project. [https://thetatools.xyz/](https://thetatools.xyz/)
+'Theta Tools' are a group of useful tools, components, and templates that can be used in any project. [https://theta-tools.github.io/](https://theta-tools.github.io/)
 
-[Discord](https://thetatools.xyz/discord)
+This repository serves as both the Main Repository, and the Repository for `https://theta-tools.github.io`.
 
-This repository serves as both the Main Repository, and the Repository for `https://thetatools.xyz`.
-
-You can find information on installation and usage at [https://theta-tools.xyz/docs](https://thetatools.xyz/docs/)
+You can find information on installation and usage at [https://theta-tools.xyz/docs](https://theta-tools.github.io/docs/)
 
 ## Contributing
 
-Please [read the docs for guidelines](https://thetatools.xyz/main#contributing)
+Please [read the docs for guidelines](https://theta-tools.github.io/main#contributing)
 
 ## License
 

--- a/delta/src/contributing.md
+++ b/delta/src/contributing.md
@@ -7,5 +7,5 @@
 5. Read and follow the `README.md` in the new website template folder
 6. Develop your website template
 7. Submit your website template, along with the `documentation.md` via a pull request
-8. [Follow the steps to add your component to the docs](https://thetatools.xyz/main#contributing)
+8. [Follow the steps to add your component to the docs](https://theta-tools.github.io/main#contributing)
 9. Wait for a moderator to approve your website template 

--- a/discord/index.html
+++ b/discord/index.html
@@ -1,3 +1,0 @@
-<head>
-    <meta http-equiv="refresh" content="0; URL=https://discord.gg/P8RyW8F"/>
-</head>

--- a/epsilon/src/contributing.md
+++ b/epsilon/src/contributing.md
@@ -4,5 +4,5 @@
 2. [Fork the repository](https://github.com/theta-tools/epsilon-set/fork)
 3. Add your CSS to the bottom of `main.css`
 4. Submit the fork / branch with your additons via a pull request
-5. [Follow the steps to add your component to the docs](https://thetatools.xyz/main/contributing)
+5. [Follow the steps to add your component to the docs](https://theta-tools.github.io/main/contributing)
 6. Wait for a moderator to approve your component

--- a/gamma/src/contributing.md
+++ b/gamma/src/contributing.md
@@ -7,5 +7,5 @@
 5. Read and follow the `README.md` in the new component folder
 6. Develop your component
 7. Submit your component, along with the `documentation.md` via a pull request
-8. [Follow the steps to add your component to the docs](https://thetatools.xyz/main/contributing)
+8. [Follow the steps to add your component to the docs](https://theta-tools.github.io/main/contributing)
 9. Wait for a moderator to approve your component

--- a/main/src/addingtothedocs.md
+++ b/main/src/addingtothedocs.md
@@ -2,8 +2,8 @@
 
 ### Adding Gamma Set and Delta Set components
 
-1. [Open an issue](https://github.com/theta-tools/main-repository/issues/new/choose)
-2. [Fork the repository](https://github.com/theta-tools/main-repository/fork)
+1. [Open an issue](https://github.com/theta-tools/theta-tools.github.io/issues/new/choose)
+2. [Fork the repository](https://github.com/theta-tools/theta-tools.github.io/fork)
 3. Copy the `documentation.md` file from the component folder into the `src` directory inside the set's directory
 4. Rename the `documentation.md` file to the name of your component
 5. Open the `index.html` file inside the set's directory
@@ -14,8 +14,8 @@
 
 ### Adding Epsilon Set components
 
-1. [Open an issue](https://github.com/theta-tools/main-repository/issues/new/choose)
-2. [Fork the repository](https://github.com/theta-tools/main-repository/fork)
+1. [Open an issue](https://github.com/theta-tools/theta-tools.github.io/issues/new/choose)
+2. [Fork the repository](https://github.com/theta-tools/theta-tools.github.io/fork)
 4. Locate the `.md` file, in the `src` directory inside the set's directory, that corresponds to your component
 5. Add your component in the same style as the rest
 6. Submit your changes via a pull request

--- a/main/src/contributing.md
+++ b/main/src/contributing.md
@@ -1,10 +1,10 @@
 # Contributing to Theta Tools
 
 ## Found a bug?
-[Send us a bug report!](https://github.com/theta-tools/main-repository/issues/new/choose)
+[Send us a bug report!](https://github.com/theta-tools/theta-tools.github.io/issues/new/choose)
 
 ## Want to contribute to our website or documentation?
-Read our guidelines below, and then [open an issue](https://github.com/theta-tools/main-repository/issues/new/choose). If you're contributing to a set's documentation, then follow the steps on the `Adding to the Docs` page.
+Read our guidelines below, and then [open an issue](https://github.com/theta-tools/theta-tools.github.io/issues/new/choose). If you're contributing to a set's documentation, then follow the steps on the `Adding to the Docs` page.
 
 ## Want to contribute code?
 If you're interested in contributing to Theta Tools, you can read our guidelines, the follow the steps in each of the sets' docs.
@@ -20,6 +20,6 @@ If you want to contribute to Theta Tools, that's great! We're always looking for
 > Your PR may be marked as `Invalid` if you don't follow these guidelines.
 
 ### Links to Sets' Docs
-[Gamma Set](https://thetatools.xyz/gamma#contributing)<br>
-[Delta Set](https://thetatools.xyz/delta#contributing)<br>
-[Epsilon Set](https://thetatools.xyz/epsilon#contributing)<br>
+[Gamma Set](https://theta-tools.github.io/gamma#contributing)<br>
+[Delta Set](https://theta-tools.github.io/delta#contributing)<br>
+[Epsilon Set](https://theta-tools.github.io/epsilon#contributing)<br>


### PR DESCRIPTION
**Linked Issue(s)**
- Resolves #5 

**Describe the changes**
All links to thetatools.xyz should now be to thetatools.github.io.

**Change(s) location**
All `contributing.md` pages.
